### PR TITLE
add support for pubsub push to http

### DIFF
--- a/go/examples/cli/README.md
+++ b/go/examples/cli/README.md
@@ -3,7 +3,7 @@
 ## Build
 
 ```bash
-go build rgw_pubsub_cli.go
+go build rgw_ps_cli.go
 ```
 
 ## Setup test environment

--- a/go/examples/cli/rgw_ps_cli.go
+++ b/go/examples/cli/rgw_ps_cli.go
@@ -40,7 +40,6 @@ var (
 	zonegroup        = flag.String("zonegroup", "", "rgw zone group")
 	topicName        = flag.String("topicname", "mytopic", "pubsub topic name")
 	subName          = flag.String("subname", "mysub", "pubsub subscription name")
-	notificationName = flag.String("notifname", "mynotification", "pubsub notification name")
 	bucketName       = flag.String("bucketname", "buck", "existing rgw bucket name")
 	cleanup          = flag.Bool("cleanup", false, "clean up after run")
 	readonly         = flag.Bool("readonly", false, "read only")
@@ -49,8 +48,8 @@ var (
 func main() {
 	flag.Parse()
 
-	glog.Infof("user name %s, topic %s, sub %s, notification %s bucket %s to-clean-up %v readonly %v",
-		*userName, *topicName, *subName, *notificationName, *bucketName, *cleanup, *readonly)
+	glog.Infof("user name %s, topic %s, sub %s, bucket %s to-clean-up %v readonly %v",
+		*userName, *topicName, *subName, *bucketName, *cleanup, *readonly)
 
 	accessId := os.Getenv(envAccessId)
 	accessKey := os.Getenv(envAccessKey)

--- a/go/examples/cli/rgw_ps_cli.go
+++ b/go/examples/cli/rgw_ps_cli.go
@@ -36,13 +36,13 @@ func init() {
 }
 
 var (
-	userName         = flag.String("username", "rgwtest", "rgw user name")
-	zonegroup        = flag.String("zonegroup", "", "rgw zone group")
-	topicName        = flag.String("topicname", "mytopic", "pubsub topic name")
-	subName          = flag.String("subname", "mysub", "pubsub subscription name")
-	bucketName       = flag.String("bucketname", "buck", "existing rgw bucket name")
-	cleanup          = flag.Bool("cleanup", false, "clean up after run")
-	readonly         = flag.Bool("readonly", false, "read only")
+	userName   = flag.String("username", "rgwtest", "rgw user name")
+	zonegroup  = flag.String("zonegroup", "", "rgw zone group")
+	topicName  = flag.String("topicname", "mytopic", "pubsub topic name")
+	subName    = flag.String("subname", "mysub", "pubsub subscription name")
+	bucketName = flag.String("bucketname", "buck", "existing rgw bucket name")
+	cleanup    = flag.Bool("cleanup", false, "clean up after run")
+	readonly   = flag.Bool("readonly", false, "read only")
 )
 
 func main() {

--- a/go/examples/knative-eventing-source/Makefile
+++ b/go/examples/knative-eventing-source/Makefile
@@ -7,19 +7,24 @@ REPO=rootfs
 all: $(TARGETS)
 
 source:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/source ./container-source
+	gofmt -s -w ./container-source && \
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/$@ ./container-source
 
 receiver:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/receiver ./receiver
+	gofmt -s -w $@ && \
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/$@ ./$@
 
 vision:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/vision ./vision
+	gofmt -s -w $@ && \
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/$@ ./$@
 
 resnet:
+	gofmt -s -w ./resnet-grpc && \
 	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/resnet ./resnet-grpc
 
 http-to-knative:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/http-to-knative ./http-to-knative
+	gofmt -s -w $@ && \
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/$@ ./$@
 
 image: $(TARGETS)
 	for t in $(TARGETS); do \

--- a/go/examples/knative-eventing-source/Makefile
+++ b/go/examples/knative-eventing-source/Makefile
@@ -1,6 +1,6 @@
-TARGETS= source receiver vision resnet
+TARGETS=source receiver vision resnet http-to-knative
 
-.PHONY: all $(TARGETS)
+.PHONY: all clean image push-image $(TARGETS)
 
 REPO=rootfs
 
@@ -18,6 +18,8 @@ vision:
 resnet:
 	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/resnet ./resnet-grpc
 
+http-to-knative:
+	CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o  _output/http-to-knative ./http-to-knative
 
 image: $(TARGETS)
 	for t in $(TARGETS); do \

--- a/go/examples/knative-eventing-source/container-source/main.go
+++ b/go/examples/knative-eventing-source/container-source/main.go
@@ -69,7 +69,6 @@ func main() {
 	log.Printf("Target is: %q", *target)
 	log.Printf("Events will be fetched from rgw: %s", endpoint)
 
-
 	var period time.Duration
 	if p, err := strconv.Atoi(*pollInt); err != nil {
 		period = time.Duration(5) * time.Second

--- a/go/examples/knative-eventing-source/container/http-to-knative/Dockerfile
+++ b/go/examples/knative-eventing-source/container/http-to-knative/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+
+COPY http-to-knative /http-to-knative
+RUN chmod +x /http-to-knative
+ENTRYPOINT ["/http-to-knative"]

--- a/go/examples/knative-eventing-source/http-to-knative/main.go
+++ b/go/examples/knative-eventing-source/http-to-knative/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
-	"encoding/json"
 
 	"github.com/knative/pkg/cloudevents"
 
@@ -21,12 +21,12 @@ const (
 )
 
 var (
-	userName  = flag.String("username", "", "rgw user name")
-	zonegroup = flag.String("zonegroup", "", "rgw zone group")
-	subName   = flag.String("subscriptionname", "", "pubsub subscription name (should exist) for scking")
-	target    = flag.String("sink", "", "uri to send events to")
-	listenPort   = flag.String("port", "8080", "listening port")
-	rgwClient *rgwpubsub.RGWClient
+	userName   = flag.String("username", "", "rgw user name")
+	zonegroup  = flag.String("zonegroup", "", "rgw zone group")
+	subName    = flag.String("subscriptionname", "", "pubsub subscription name (should exist) for scking")
+	target     = flag.String("sink", "", "uri to send events to")
+	listenPort = flag.String("port", "8080", "listening port")
+	rgwClient  *rgwpubsub.RGWClient
 )
 
 func postHandler(w http.ResponseWriter, r *http.Request) {
@@ -47,8 +47,8 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 
 	var e rgwpubsub.RGWEvent
 	err = json.Unmarshal(body, &e)
-	
-    if err != nil {
+
+	if err != nil {
 		log.Printf("Failed to parse JSON notification: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -100,7 +100,7 @@ func main() {
 	log.Printf("Events will acked to rgw: %s", endpoint)
 
 	http.HandleFunc("/", postHandler)
-    log.Fatal(http.ListenAndServe(":"+*listenPort, nil))
+	log.Fatal(http.ListenAndServe(":"+*listenPort, nil))
 }
 
 // Creates a CloudEvent Context for a pubsub event.


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

adding a new binary which is listening on events coming from rgw/pubsub, and posting them into knative.
this could be used for the existing usecases, without the need for polling. 
note that the subscription created on rgw requires and endpoint definition.

this was only tested as standalone binary, not tested in knative yet.
also added some more logs in the exiting code, as well as cleanups.