### PR TITLE
Support AMQP push endpoints.

### DIFF
--- a/go/examples/cli/rgw_ps_cli.go
+++ b/go/examples/cli/rgw_ps_cli.go
@@ -44,6 +44,8 @@ var (
 	cleanup      = flag.Bool("cleanup", false, "clean up after run")
 	readonly     = flag.Bool("readonly", false, "read only")
 	pushEndpoint = flag.String("pushendpoint", "", "URL of endpoint to push notifications to")
+	amqpExchange = flag.String("amqp-exchange", "", "Name of the exchange for AMQP push endpoints")
+	amqpAckLevel = flag.String("amqp-ack-level", "", "Ack level for AMQP push endpoints")
 )
 
 func main() {
@@ -82,7 +84,7 @@ func main() {
 	glog.Infof("notifications: %+v", notif)
 	if !*readonly {
 		// create subscription
-		err = rgwClient.RGWCreateSubscription(*subName, *topicName, *pushEndpoint)
+		err = rgwClient.RGWCreateSubscription(*subName, *topicName, *pushEndpoint, *amqpExchange, *amqpAckLevel)
 		if err != nil {
 			glog.Fatalf("failed to create subscription: %v", err)
 		}


### PR DESCRIPTION
This pull request adds support for creating PubSub subscriptions with AMQP endpoints.

It adds the missing HTTP request parameter `amqp-exchange` (which, according to http://docs.ceph.com/docs/nautilus/radosgw/pubsub-module/#create-subscription, is mandatory for AMQP push endpoints).

The HTTP request parameter `amqp-ack-level` is also sent if it's not blank.