### PR TITLE
Fix error handling.

### DIFF
--- a/go/pkg/notifications.go
+++ b/go/pkg/notifications.go
@@ -66,10 +66,11 @@ func (rgw *RGWClient) RGWGetNotifications(bucket string) (*RGWNotifications, err
 	req_url := rgw.endpoint + "/notifications/bucket/" + bucket
 	out, err := rgw.rgwDoRequestRaw(method, req_url)
 	if err != nil {
-		if err = json.Unmarshal(out, &topics); err != nil {
-			glog.Warningf("failed to unmarshal topics from %s: %v", string(out), err)
-			return nil, err
-		}
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &topics); err != nil {
+		glog.Warningf("failed to unmarshal topics from %s: %v", string(out), err)
+		return nil, err
 	}
 	return &topics, nil
 }

--- a/go/pkg/subscriptions.go
+++ b/go/pkg/subscriptions.go
@@ -116,11 +116,12 @@ func (rgw *RGWClient) RGWGetEvents(sub string, max int, marker string) (*RGWEven
 		req_url = req_url + "&marker=" + marker
 	}
 	out, err := rgw.rgwDoRequestRaw(method, req_url)
-	if err == nil {
-		if err = json.Unmarshal(out, &events); err != nil {
-			glog.Warningf("failed to unmarshal events from %s: %v", string(out), err)
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &events); err != nil {
+		glog.Warningf("failed to unmarshal events from %s: %v", string(out), err)
+		return nil, err
 	}
 	return &events, nil
 }

--- a/go/pkg/topics.go
+++ b/go/pkg/topics.go
@@ -71,10 +71,11 @@ func (rgw *RGWClient) RGWGetSubscriptionWithTopic(topic string) (*RGWSubscriptio
 	req_url := rgw.endpoint + "/topics/" + topic
 	out, err := rgw.rgwDoRequestRaw(method, req_url)
 	if err != nil {
-		if err = json.Unmarshal(out, &sub); err != nil {
-			glog.Warningf("failed to unmarshal sub from %s: %v", string(out), err)
-			return nil, err
-		}
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &sub); err != nil {
+		glog.Warningf("failed to unmarshal sub from %s: %v", string(out), err)
+		return nil, err
 	}
 	return &sub, nil
 }
@@ -86,10 +87,11 @@ func (rgw *RGWClient) RGWGetSubscriptions() (*RGWSubscriptions, error) {
 	req_url := rgw.endpoint + "/topics"
 	out, err := rgw.rgwDoRequestRaw(method, req_url)
 	if err != nil {
-		if err = json.Unmarshal(out, &subs); err != nil {
-			glog.Warningf("failed to unmarshal subs from %s: %v", string(out), err)
-			return nil, err
-		}
+		return nil, err
+	}
+	if err = json.Unmarshal(out, &subs); err != nil {
+		glog.Warningf("failed to unmarshal subs from %s: %v", string(out), err)
+		return nil, err
 	}
 	return &subs, nil
 }


### PR DESCRIPTION
In several `RGWGet*` functions, the error handling flow seems to be the other way around, and empty responses are returned when the HTTP calls succeed.

Please note that I' a Go newbie, so treat this pull request with caution :)